### PR TITLE
update gps.conf for a quicker fix on hlte

### DIFF
--- a/gps/etc/gps.conf
+++ b/gps/etc/gps.conf
@@ -24,7 +24,7 @@ NTP_SERVER=time.gpsonextra.net
 DEBUG_LEVEL = 1
 
 # Intermediate position report, 1=enable, 0=disable
-INTERMEDIATE_POS=0
+INTERMEDIATE_POS=1
 
 # supl version 1.0
 SUPL_VER=0x10000
@@ -69,7 +69,7 @@ LPP_PROFILE = 3 # Sensor R&D : This will not be injected to MODEM
 # EXTRA SETTINGS
 ################################
 # NMEA provider (1=Modem Processor, 0=Application Processor)
-NMEA_PROVIDER=1
+NMEA_PROVIDER=0
 
 ##################################################
 # Select Positioning Protocol on A-GLONASS system


### PR DESCRIPTION
gps only fix on hlte is really slow, so slow that I don't ever remember obtaining a fix running cyanogenmod (even with 6, 7 satellites the position remains unknown).

Using the application processor as the NMEA provider and enabling intermediate position report fixes the issue for me on both cm 11 m12 and cm12 nightlies.
